### PR TITLE
save path to file info after writing

### DIFF
--- a/process-dataset/steps/upload-file-info.js
+++ b/process-dataset/steps/upload-file-info.js
@@ -52,7 +52,8 @@ const uploadFileInfo = async (firebaseHandler, readFolder, uploadFileInfo) => {
     await writeBatch();
     console.log("uploading file info complete")
     return {
-        cellLineData: `cell-data/${firebaseHandler.id}/cell-line-def`
+        cellLineDataPath: firebaseHandler.cellRef.collection(firebaseHandler.cellLineDefEndpoint).path,
+        fileInfoPath: firebaseHandler.cellRef.collection(firebaseHandler.cellFileInfoEndpoint).path,
     }
 }
 


### PR DESCRIPTION
Before: fileInfoPath was hardcoded instead of data driven

Now: Stored in database after upload