### PR TITLE
Feature/update cell lines

### DIFF
--- a/process-dataset/constants.js
+++ b/process-dataset/constants.js
@@ -6,6 +6,8 @@ const CELL_LINE_DEF_NAME_KEY = "CellLineId_Name";
 const CELL_LINE_DEF_STRUCTURE_KEY = "StructureId_Name";
 const CELL_LINE_DEF_PROTEIN_KEY = "ProteinId_DisplayName";
 const PROTEIN_DISPLAY_NAME_KEY = 'ProteinId_DisplayName';
+const GENE_NAME_KEY = "GeneId_Name";
+const GENE_FULL_NAME_KEY = "GeneId_FullName";
 const TEMP_LOCAL_FILE_INFO_JSON = "file-info.json";
 const TEMP_LOCAL_CELL_FEATURE_JSON = "cell-feature-analysis.json";
 const FILE_INFO_KEYS = [
@@ -29,5 +31,7 @@ module.exports = {
     PROTEIN_DISPLAY_NAME_KEY,
     FILE_INFO_KEYS,
     TEMP_LOCAL_FILE_INFO_JSON,
-    TEMP_LOCAL_CELL_FEATURE_JSON
+    TEMP_LOCAL_CELL_FEATURE_JSON,
+    GENE_FULL_NAME_KEY, 
+    GENE_NAME_KEY
 }

--- a/process-dataset/firebase/firebase-handler.js
+++ b/process-dataset/firebase/firebase-handler.js
@@ -85,7 +85,16 @@ class FirebaseHandler {
     }
 
     uploadArrayUsingKeys(array, collectionName, docKey) {
-        return Promise.all(array.map((ele) => firestore.collection(collectionName).doc(ele[docKey]).set(ele)))
+        return Promise.all(array.map( async(ele) => {
+            const doc = await firestore.collection(collectionName).doc(ele[docKey]).get()
+            if (doc.exists) {
+                return firestore.collection(collectionName).doc(ele[docKey]).update(ele)
+
+            } else {
+
+                return firestore.collection(collectionName).doc(ele[docKey]).set(ele)
+            }
+        }))
     }
 }
 

--- a/process-dataset/firebase/firebase-handler.js
+++ b/process-dataset/firebase/firebase-handler.js
@@ -89,9 +89,7 @@ class FirebaseHandler {
             const doc = await firestore.collection(collectionName).doc(ele[docKey]).get()
             if (doc.exists) {
                 return firestore.collection(collectionName).doc(ele[docKey]).update(ele)
-
             } else {
-
                 return firestore.collection(collectionName).doc(ele[docKey]).set(ele)
             }
         }))


### PR DESCRIPTION
The older dataset didn't have gene names in the cell lines, but both datasets write to the unified cell line list, so when I ran the older dataset, it was removing the gene names that had been added by the new dataset. 

I fixed this by checking if a value exists first and doing and update (which doesn't remove and values) if it does exist