### PR TITLE
Feature/publication data

### DIFF
--- a/dataset-2-1/dataset.json
+++ b/dataset-2-1/dataset.json
@@ -3,7 +3,14 @@
   "version": "2021.1",
   "name": "aics_hipsc",
   "image": "card-cover-dataset-2-0.png",
-  "description": "Through improved cell and nuclear segmentation methods, this dataset contains 5x the number of single-cell images and includes 5 new fluorescently-labeled structures. To learn more about the robust intracellular organization found in this dataset, please see our recent article in <a href='https://www.biorxiv.org/content/10.1101/2020.12.08.415562v1'>bioRxiv.</a>",
+  "description": "Through improved cell and nuclear segmentation methods, this dataset contains 5x the number of single-cell images and includes 5 new fluorescently-labeled structures. To learn more about the robust intracellular organization found in this dataset, please see our recent article in bioRxiv.",
+  "publications": [
+    {
+      "title": "Robust integrated intracellular organization of the human iPS cell: where, how much, and how variable",
+      "url": "https://www.biorxiv.org/content/10.1101/2020.12.08.415562v2",
+      "citation": "bioRxiv, 2021"
+    }
+  ],
   "userData": {
     "isNew": false,
     "inReview": true,

--- a/dataset-cellsystems-2021/dataset.json
+++ b/dataset-cellsystems-2021/dataset.json
@@ -3,14 +3,9 @@
     "name": "cellsystems",
     "publications": [
         {
-            "title": "",
-            "url": "",
-            "citation": ""
-        },
-        {
-            "title": "",
-            "url": "",
-            "citation": ""
+            "title": "Cell states beyond transcriptomics: Integrating structural organization and gene expression in hiPSC-derived cardiomyocytes",
+            "url": "https://www.cell.com/cell-systems/fulltext/S2405-4712(21)00156-3?_returnURL=https%3A%2F%2Flinkinghub.elsevier.com%2Fretrieve%2Fpii%2FS2405471221001563%3Fshowall%3Dtrue",
+            "citation": "Cell Systems, May 2021"
         }
     ],
     "datasets": [

--- a/dataset-cellsystems-2021/fish/dataset.json
+++ b/dataset-cellsystems-2021/fish/dataset.json
@@ -3,7 +3,7 @@
   "version": "2021.1",
   "name": "cellsystems_fish",
   "image": "thumb_rnafish.png",
-  "description": "This dataset contains images of fixed hiPSC-derived cardiomyocytes from our recent article in <a href='https://doi.org/10.1016/j.cels.2021.05.001'>Cell Systems.</a> This dataset integrates analysis of gene expression by RNA FISH with automated image-based classification of sarcomeric z-disk organization to classify cell states.",
+  "description": "TThis dataset is one of the two datasets accompanying the Cell Systems manuscript. This one presents RNA-FISH imaging data of fixed cardiomyocytes at different timepoints. For more information please click on the link below to access the manuscript.",
   "userData": {
     "isNew": true,
     "inReview": false,

--- a/dataset-cellsystems-2021/fish/dataset.json
+++ b/dataset-cellsystems-2021/fish/dataset.json
@@ -3,7 +3,7 @@
   "version": "2021.1",
   "name": "cellsystems_fish",
   "image": "thumb_rnafish.png",
-  "description": "TThis dataset is one of the two datasets accompanying the Cell Systems manuscript. This one presents RNA-FISH imaging data of fixed cardiomyocytes at different timepoints. For more information please click on the link below to access the manuscript.",
+  "description": "This dataset is one of the two datasets accompanying the Cell Systems manuscript. This one presents RNA-FISH imaging data of fixed cardiomyocytes at different timepoints. For more information please click on the link below to access the manuscript.",
   "userData": {
     "isNew": true,
     "inReview": false,

--- a/dataset-cellsystems-2021/live/dataset.json
+++ b/dataset-cellsystems-2021/live/dataset.json
@@ -3,7 +3,7 @@
   "version": "2021.1",
   "name": "cellsystems_live",
   "image": "thumb_livecardio.png",
-  "description": "This dataset contains images of live hiPSC-derived cardiomyocytes from our recent article in <a href='https://doi.org/10.1016/j.cels.2021.05.001'>Cell Systems</a> that developed a quantitative, imaging-based platform for the systematic and automated classification of sarcomeric z-disk organization using alpha-actinin-2.",
+  "description": "This dataset is one of the two datasets accompanying the Cell Systems manuscript. This one presents live-captured FOVs of cardiomyocytes at different timepoints. For more information please click on the link below to access the manuscript.",
   "userData": {
     "isNew": true,
     "inReview": false,

--- a/process-dataset/index.js
+++ b/process-dataset/index.js
@@ -91,6 +91,7 @@ const processMegaset = async () => {
         // Do the same processing as for a real megaset, but much simpler since all data is
         // contained in the top-level dataset.json
         megasetInfo.title = topLevelJson.title;
+        megasetInfo.publications = topLevelJson.publications || [];
         topLevelJson.datasetReadFolder = inputFolder;
         const datasetInfo = getDatasetInfo(topLevelJson);
         const id = getDatasetId(datasetInfo);


### PR DESCRIPTION
Part of work to resolve [CFE-128 Implement megacard design](https://aicsjira.corp.alleninstitute.org/browse/CFE-128)

I've added a `publications` field to top-level `dataset.json` files in each megaset. I also updated the `description` fields to match the copy in the [Zeplin mockup](https://app.zeplin.io/project/5e8e3eaf2a0a0e2152f37e19/screen/60f86dd6cccc9512dfd90771). 

With the above changes, the `process-dataset` script needed 1 line added to get the publication data in single-dataset "megasets" into Firebase.

I've run the process-dataset script for dev-db and things are looking good:

![image](https://user-images.githubusercontent.com/12690133/151260418-a54dfcbd-42b5-452e-8d08-57d265be7d7f.png)
