### PR TITLE
Fix/fish groups

### DIFF
--- a/dataset-2-1/feature_defs.json
+++ b/dataset-2-1/feature_defs.json
@@ -202,6 +202,7 @@
     "displayName": "Labeled Structure",
     "description": "Name of the cellular structure that has been fluorescently labeled in each cell line",
     "tooltip": "Name of the cellular structure that has been fluorescently labeled in each cell line",
+    "unit": "",
     "discrete": true,
     "options": {
       "5": {

--- a/dataset-cellsystems-2021/fish/feature_defs.json
+++ b/dataset-cellsystems-2021/fish/feature_defs.json
@@ -528,12 +528,12 @@
     "discrete": true,
     "options": {
       "0": {
-        "color": "#1F77B4",
-        "name": "MYH6-MYH7"
-      },
-      "1": {
         "color": "#FF7F0E",
         "name": "HPRT1-COL2A1"
+      },
+      "1": {
+        "color": "#1F77B4",
+        "name": "MYH6-MYH7"
       },
       "2": {
         "color": "#2CA02C",


### PR DESCRIPTION
The wrong fish target was being grayed out on the default page: [staging.cfe.allencell.org](http://staging.cfe.allencell.org/?cellSelectedFor3D=F0219C05&colorBy=cell-age&dataset=cellsystems_fish_v2021.1&plotByOnX=cos&plotByOnY=cell-area&selectedPoint%5B0%5D=F0219C05)
I already ran the script so the correct FISH target should be on by default, but there is another issue with the `HPRT1-COL2A1` being grayed out that I have a fix for on the front end. 

@tanyasg can you check your own scripts to make sure this change makes sense? I don't want us to update this data in the future and then re-introduce this bug. 
Basically the change is 
`0` used to map to `MYH6-MYH7` and `1` used to map to `HPRT1-COL2A1`
And now: 
`0` maps to `HPRT1-COL2A1` and `1` maps to `MYH6-MYH7`

I made this switch based on the cell counts for each target. All the other ones seemed correct. 