### PR TITLE
fix the regex for H3342 channel

### DIFF
--- a/dataset-2-1/images.json
+++ b/dataset-2-1/images.json
@@ -3,7 +3,7 @@
         {"name":"Observed channels", "channels": [
             {"name": "Membrane", "match": ["(CMDRP)"], "color": "E2CDB3", "enabled":true, "lut":["p50","p98"]},
             {"name": "Labeled structure", "match": ["(EGFP)|(RFPT)"], "color": "6FBA11", "enabled":true, "lut":["p50","p98"]},
-            {"name": "DNA", "match": ["/(H3342)/"], "color": "8DA3C0", "enabled":true, "lut":["p50","p98"]},
+            {"name": "DNA", "match": ["(H3342)"], "color": "8DA3C0", "enabled":true, "lut":["p50","p98"]},
             {"name": "Bright field", "match": ["(100)|(Bright)"], "color": "F5F1CB", "enabled":false, "lut":["p50","p98"]}
         ]},
         {"name":"Segmentation channels", "channels": [


### PR DESCRIPTION
Extra slashes were messing up the name matching and all H3342 channels were going into group "Other".