### PR TITLE
Feature/publish to production

### DIFF
--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -19,12 +19,7 @@ on:
         - staging
         - production
       
-
-jobs:
-  release_dataset: 
-    name: Release Dataset
-    runs-on: ubuntu-latest
-    env:
+env:
       NODE_ENV: ${{ github.event.inputs.database }}
       STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}
       STAGING_FIREBASE_EMAIL: ${{ secrets.STAGING_FIREBASE_EMAIL }}
@@ -33,7 +28,21 @@ jobs:
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
       ADMINS: ${{ secrets.OWNERS }}
+
+jobs:
+  release_dataset: 
+    name: Release Dataset
+    runs-on: ubuntu-latest
     if: ${{ (github.ref == 'refs/heads/main') && contains($ADMINS, ${{ github.triggering_actor }}) }}
+    # env:
+    #   NODE_ENV: ${{ github.event.inputs.database }}
+    #   STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}
+    #   STAGING_FIREBASE_EMAIL: ${{ secrets.STAGING_FIREBASE_EMAIL }}
+    #   FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+    #   FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
+    #   AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
+    #   AWS_ID: ${{ secrets.CFE_AWS_ID }}
+    #   ADMINS: ${{ secrets.OWNERS }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -30,6 +30,7 @@ jobs:
         id: check
         run: | 
           echo "ADMINS=${{ env.ADMINS }}" >> $GITHUB_OUTPUT
+          echo "${{ steps.check.outputs.ADMINS }}"
         
   release_dataset: 
     name: Release Dataset
@@ -44,7 +45,7 @@ jobs:
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
       ADMINS: ${{ secrets.OWNERS }}
-    if: contains(needs.check_user.outputs.ADMINS, github.triggering_actor)
+    if: contains(needs.check_user.outputs.ADMINS, github.triggering_actor) #&& github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
@@ -61,5 +62,3 @@ jobs:
           echo "${{ github.triggering_actor }}"
           echo "${{ github.actor }}"
           echo "${{ github.ref }}"
-          echo "${{ steps.check.outputs.ADMINS }}"
-

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -33,7 +33,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: ${{ (github.ref == 'refs/heads/main') && contains(env.ADMINS, ${{ github.triggering_actor }}) }}
+    if: ${{ (github.ref == 'refs/heads/main') && contains(${{ secrets.OWNERS }}, ${{ github.triggering_actor }}) }}
     # env:
     #   NODE_ENV: ${{ github.event.inputs.database }}
     #   STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -59,6 +59,6 @@ jobs:
         run: |
           echo "${{ github.triggering_actor }}"
           echo "${{ github.actor }}"
-          echo "${{ $ADMINS }}"
+          echo "${{ env.ADMINS }}"
           echo "${{ github.ref }}"
 

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -43,7 +43,7 @@ jobs:
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
       ADMINS: ${{ secrets.OWNERS }}
-    if: contains(env.ADMINS, github.triggering_actor)
+    if: contains($ADMINS, github.triggering_actor)
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
@@ -59,6 +59,6 @@ jobs:
         run: |
           echo "${{ github.triggering_actor }}"
           echo "${{ github.actor }}"
-          echo "${{ env.ADMINS }}"
+          echo "$ADMINS"
           echo "${{ github.ref }}"
 

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -34,7 +34,8 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: (github.ref == 'refs/heads/main') && contains($ADMINTEST, ${{ github.triggering_actor }})
+    if: ${{ env.ADMINTEST == github.triggering_actor }}
+    # if: (github.ref == 'refs/heads/main') && contains($ADMINTEST, ${{ github.triggering_actor }})
     # env:
     #   NODE_ENV: ${{ github.event.inputs.database }}
     #   STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -24,7 +24,6 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: ${{ (github.ref == 'refs/heads/main') && contains($ADMINS, ${{ github.triggering_actor }}) }}
     env:
       NODE_ENV: ${{ github.event.inputs.database }}
       STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}
@@ -34,6 +33,7 @@ jobs:
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
       ADMINS: ${{ secrets.OWNERS }}
+    if: ${{ (github.ref == 'refs/heads/main') && contains($ADMINS, ${{ github.triggering_actor }}) }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -33,7 +33,7 @@ jobs:
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
       ADMINS: "meganrm, toloudis"
-    if: contains(env.ADMINS, github.actor)
+    if: contains($ADMINS, github.actor)
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -47,7 +47,7 @@ jobs:
     name: Release Dataset
     runs-on: ubuntu-latest
     # needs: [check_user]
-    if: contains($ADMINS, github.triggering_actor) #&& github.ref == 'refs/heads/main'
+    if: contains(env.ADMINS, github.triggering_actor) #&& github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -24,7 +24,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: ${{ contains(fromJson(env.ADMINS), ${{ github.triggering_actor }}) }}
+    if: ${{ contains($ADMINS, ${{ github.triggering_actor }}) }}
     env:
       NODE_ENV: ${{ github.event.inputs.database }}
       STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -24,7 +24,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: contains(fromJson(env.ADMINS), ${{ github.triggering_actor }})
+    if: ${{ contains(fromJson(env.ADMINS), ${{ github.triggering_actor }}) }}
     env:
       NODE_ENV: ${{ github.event.inputs.database }}
       STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -19,7 +19,25 @@ on:
         - staging
         - production
 
-env:
+
+jobs:
+  # check_user:
+  #   name: Authorization Check
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     ADMINS: ${{ steps.check.outputs.ADMINS }}
+  #   steps: 
+  #     - name: Make env variable ADMINS global
+  #       id: check
+  #       run: | 
+  #         echo "ADMINS=${{ env.ADMINS }}" >> $GITHUB_OUTPUT
+  #         echo "${{ steps.check.outputs.ADMINS }}" 
+        
+  release_dataset: 
+    name: Release Dataset
+    runs-on: ubuntu-latest
+    # needs: [check_user]
+    env:
       NODE_ENV: ${{ github.event.inputs.database }}
       STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}
       STAGING_FIREBASE_EMAIL: ${{ secrets.STAGING_FIREBASE_EMAIL }}
@@ -27,27 +45,8 @@ env:
       FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
-      ADMINS: ${{ secrets.OWNERS }} # meganrm, rugeli, toloudis
-
-jobs:
-  check_user:
-    name: Authorization Check
-    runs-on: ubuntu-latest
-    outputs:
-      ADMINS: ${{ steps.check.outputs.ADMINS }}
-    steps: 
-      - name: Make env variable ADMINS global
-        id: check
-        run: | 
-          echo "ADMINS=${{ env.ADMINS }}" >> $GITHUB_OUTPUT
-          echo "${{ steps.check.outputs.ADMINS }}" 
-        # echo ${{ steps.check.outputs.ADMINS }} == ""
-        
-  release_dataset: 
-    name: Release Dataset
-    runs-on: ubuntu-latest
-    needs: [check_user]
-    if: contains(needs.check_user.outputs.ADMINS, github.triggering_actor) #&& github.ref == 'refs/heads/main'
+      ADMINS: "meganrm, rugeli, toloudis" #${{ secrets.OWNERS }}
+    if: contains($ADMINS, github.triggering_actor) #&& github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
@@ -64,3 +63,4 @@ jobs:
           echo "${{ github.triggering_actor }}"
           echo "${{ github.actor }}"
           echo "${{ github.ref }}"
+          echo "${{ env.ADMINS }}"

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -24,7 +24,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: ${{ contains($ADMINS, ${{ github.triggering_actor }}) }}
+    if: contains($ADMIN, ${{ github.triggering_actor }})
     env:
       NODE_ENV: ${{ github.event.inputs.database }}
       STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}
@@ -33,7 +33,7 @@ jobs:
       FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
-      ADMINS: ("meganrm", "toloudis") #${{ secrets.OWNERS }}
+      ADMIN: "meganrm", "toloudis1" #${{ secrets.OWNERS }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
@@ -48,6 +48,6 @@ jobs:
       - name: test
         run: echo "${{ github.triggering_actor }}"
       - name: admins
-        run: echo "${{ env.ADMINS }}"
+        run: echo "${{ env.ADMIN }}"
       
 

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -33,7 +33,7 @@ jobs:
       FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
-      ADMINS: "meganrm, rugeli, toloudis"
+      ADMINS: "meganrm, toloudis"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -44,6 +44,9 @@ jobs:
       - run: npm ci
       - name: Release dataset
         if: contains(env.ADMINS, github.triggering_actor)
-        run: npm run release-dataset ${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }}
-      - name: specify database 
-        run: echo "${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }} is successfully released to ${{ github.event.inputs.database }} database."
+        run: |
+          npm run release-dataset ${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }}
+          echo "${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }} is successfully released to ${{ github.event.inputs.database }} database."
+      - name: Not authorized to release dataset
+        if: ${{ !contains(env.ADMINS, github.triggering_actor) }}
+        run: echo "Failed to release dataset. Please contact the owner of the repository to obtain the permission."

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -33,7 +33,7 @@ jobs:
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
       ADMINS: "meganrm, toloudis"
-    if: contains($ADMINS, ${{ github.triggering_actor }})
+    if: contains(env.ADMINS, ${{ github.actor }})
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -45,4 +45,9 @@ jobs:
         run: npm run release-dataset ${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }}
       - name: specify database 
         run: echo "${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }} is successfully released to ${{ github.event.inputs.database }} database."
+      - name: debug
+        run: |
+          echo "${{ github.triggering_actor }}"
+          echo "$ADMINS"
+          echo "${{ github.ref }}"
 

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -33,7 +33,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: ${{ (github.ref == 'refs/heads/main') && contains(${{ secrets.OWNERS }}, ${{ github.triggering_actor }}) }}
+    if: (github.ref == 'refs/heads/main') && contains(${{ secrets.OWNERS }}, ${{ github.triggering_actor }})
     # env:
     #   NODE_ENV: ${{ github.event.inputs.database }}
     #   STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -33,7 +33,7 @@ jobs:
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
       ADMINS: "meganrm, toloudis"
-    if: contains($ADMINS, github.actor)
+    if: contains('${{ env.ADMINS }}', github.actor)
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -24,6 +24,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
+    if: contains(secrets.OWNERS, github.actor)
     env:
       NODE_ENV: ${{ github.event.inputs.database }}
       STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}
@@ -32,8 +33,7 @@ jobs:
       FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
-      ADMINS: "meganrm, toloudis"
-    if: contains('${{ ADMINS }}', github.actor)
+      ADMINS: ${{ secrets.OWNERS }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -33,7 +33,7 @@ jobs:
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
       ADMINS: "meganrm, toloudis"
-    if: contains(env.ADMINS, ${{ github.actor }})
+    if: contains(env.ADMINS, github.actor)
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -24,7 +24,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: contains($ADMINS, ${{ github.triggering_actor }})
+    if: github.ref == 'refs/heads/main' && contains($ADMINS, ${{ github.triggering_actor }})
     env:
       NODE_ENV: ${{ github.event.inputs.database }}
       STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}
@@ -45,6 +45,4 @@ jobs:
         run: npm run release-dataset ${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }}
       - name: specify database 
         run: echo "${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }} is successfully released to ${{ github.event.inputs.database }} database."
-      - name: admins
-        run: echo "${{ env.ADMINS }}"
 

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -33,7 +33,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: ${{ (github.ref == 'refs/heads/main') && contains($ADMINS, ${{ github.triggering_actor }}) }}
+    if: ${{ (github.ref == 'refs/heads/main') && contains(${{$ADMINS}}, ${{ github.triggering_actor }}) }}
     # env:
     #   NODE_ENV: ${{ github.event.inputs.database }}
     #   STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -33,7 +33,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: ${{ (github.ref == 'refs/heads/main') && contains(${{env.ADMINS}}, ${{ github.triggering_actor }}) }}
+    if: ${{ (github.ref == 'refs/heads/main') && contains(env.ADMINS, ${{ github.triggering_actor }}) }}
     # env:
     #   NODE_ENV: ${{ github.event.inputs.database }}
     #   STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -28,12 +28,13 @@ env:
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
       ADMINS: ${{ secrets.OWNERS }}
+      ADMINTEST: "string"
 
 jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: (github.ref == 'refs/heads/main') && contains($secrets.OWNERS, ${{ github.triggering_actor }})
+    if: (github.ref == 'refs/heads/main') && contains($ADMINTEST, ${{ github.triggering_actor }})
     # env:
     #   NODE_ENV: ${{ github.event.inputs.database }}
     #   STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -24,7 +24,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: contains($ADMINS, ${{ github.triggering_actor }})
+    if: contains(fromJson(env.ADMINS, ${{ github.triggering_actor }})
     env:
       NODE_ENV: ${{ github.event.inputs.database }}
       STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}
@@ -33,7 +33,7 @@ jobs:
       FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
-      ADMINS: 'meganrm, toloudis' #${{ secrets.OWNERS }}
+      ADMINS: ("meganrm", "toloudis") #${{ secrets.OWNERS }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -24,7 +24,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: (github.ref == 'refs/heads/main') && contains($ADMINS, ${{ github.triggering_actor }})
+    if: ${{ (github.ref == 'refs/heads/main') && contains($ADMINS, ${{ github.triggering_actor }}) }}
     env:
       NODE_ENV: ${{ github.event.inputs.database }}
       STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -34,7 +34,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if:  github.ref == 'refs/heads/main'
+    # if:  github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -34,7 +34,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    # if:  github.ref == 'refs/heads/main'
+    if:  github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -19,25 +19,7 @@ on:
         - staging
         - production
 
-
-jobs:
-  # check_user:
-  #   name: Authorization Check
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     ADMINS: ${{ steps.check.outputs.ADMINS }}
-  #   steps: 
-  #     - name: Make env variable ADMINS global
-  #       id: check
-  #       run: | 
-  #         echo "ADMINS=${{ env.ADMINS }}" >> $GITHUB_OUTPUT
-  #         echo "${{ steps.check.outputs.ADMINS }}" 
-        
-  release_dataset: 
-    name: Release Dataset
-    runs-on: ubuntu-latest
-    # needs: [check_user]
-    env:
+env:
       NODE_ENV: ${{ github.event.inputs.database }}
       STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}
       STAGING_FIREBASE_EMAIL: ${{ secrets.STAGING_FIREBASE_EMAIL }}
@@ -46,7 +28,26 @@ jobs:
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
       ADMINS: "meganrm, rugeli, toloudis" #${{ secrets.OWNERS }}
-    if: contains($ADMINS, github.triggering_actor) #&& github.ref == 'refs/heads/main'
+
+
+jobs:
+  check_user:
+    name: Authorization Check
+    runs-on: ubuntu-latest
+    outputs:
+      admins: ${{ steps.check.outputs.admins }}
+    steps: 
+      - name: Env variable ADMINS to output
+        id: check
+        run: | 
+          echo "admins=${{ env.ADMINS }}" >> $GITHUB_OUTPUT
+          echo "${{ steps.check.outputs.admins }}" 
+        
+  release_dataset: 
+    name: Release Dataset
+    runs-on: ubuntu-latest
+    needs: [check_user]
+    if: contains(${{ needs.check_user.outputs.admins }}, github.triggering_actor) #&& github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -29,8 +29,9 @@ jobs:
       - name: Make env variable ADMINS global
         id: check
         run: | 
-          echo "ADMINS=${{ env.ADMINS }}" >> $GITHUB_OUTPUT
-          echo "${{ steps.check.outputs.ADMINS }}"
+          echo "ADMINS=${{ secrets.OWNERS }}" >> $GITHUB_OUTPUT
+          echo "${{ steps.check.outputs.ADMINS }}" 
+        # echo ${{ steps.check.outputs.ADMINS }} == ""
         
   release_dataset: 
     name: Release Dataset
@@ -44,7 +45,7 @@ jobs:
       FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
-      ADMINS: ${{ secrets.OWNERS }}
+      # ADMINS: ${{ secrets.OWNERS }} # meganrm, rugeli, toloudis
     if: contains(needs.check_user.outputs.ADMINS, github.triggering_actor) #&& github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -20,14 +20,14 @@ on:
         - production
 
 env:
-      NODE_ENV: ${{ github.event.inputs.database }}
-      STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}
-      STAGING_FIREBASE_EMAIL: ${{ secrets.STAGING_FIREBASE_EMAIL }}
-      FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-      FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
-      AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
-      AWS_ID: ${{ secrets.CFE_AWS_ID }}
-      ADMINS: ${{ secrets.OWNERS }}
+  NODE_ENV: ${{ github.event.inputs.database }}
+  STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}
+  STAGING_FIREBASE_EMAIL: ${{ secrets.STAGING_FIREBASE_EMAIL }}
+  FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+  FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
+  AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
+  AWS_ID: ${{ secrets.CFE_AWS_ID }}
+  ADMINS: ${{ secrets.OWNERS }}
 
 
 jobs:     

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -31,23 +31,23 @@ env:
 
 
 jobs:
-  check_user:
-    name: Authorization Check
-    runs-on: ubuntu-latest
-    outputs:
-      admins: ${{ steps.check.outputs.admins }}
-    steps: 
-      - name: Env variable ADMINS to output
-        id: check
-        run: | 
-          echo "admins=${{ env.ADMINS }}" >> $GITHUB_OUTPUT
-          echo "${{ steps.check.outputs.admins }}" 
+  # check_user:
+  #   name: Authorization Check
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     admins: ${{ steps.check.outputs.admins }}
+  #   steps: 
+  #     - name: Env variable ADMINS to output
+  #       id: check
+  #       run: | 
+  #         echo "admins=${{ env.ADMINS }}" >> $GITHUB_OUTPUT
+  #         echo "${{ steps.check.outputs.admins }}" 
         
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    needs: [check_user]
-    if: contains(${{ needs.check_user.outputs.admins }}, github.triggering_actor) #&& github.ref == 'refs/heads/main'
+    # needs: [check_user]
+    if: contains($ADMINS, github.triggering_actor) #&& github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
@@ -55,13 +55,12 @@ jobs:
         with:
           node-version: 16.x
       - run: npm ci
-      - name: Release dataset
-        run: npm run release-dataset ${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }}
+      # - name: Release dataset
+      #   run: npm run release-dataset ${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }}
       - name: specify database 
         run: echo "${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }} is successfully released to ${{ github.event.inputs.database }} database."
       - name: debug
         run: |
           echo "${{ github.triggering_actor }}"
-          echo "${{ github.actor }}"
           echo "${{ github.ref }}"
           echo "${{ env.ADMINS }}"

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -33,7 +33,7 @@ jobs:
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
       ADMINS: "meganrm, toloudis"
-    if: github.ref == 'refs/heads/main' && contains(split(env.ADMINS, ','), github.actor) #working, next step -- only admins can run e.g. && contains($ADMINS, ${{ github.triggering_actor }}) 
+    if: contains(split(env.ADMINS, ','), github.actor) 
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -24,7 +24,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: contains(secrets.OWNERS, github.actor)
+    if: contains($ADMINS, ${{ github.triggering_actor }})
     env:
       NODE_ENV: ${{ github.event.inputs.database }}
       STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}
@@ -33,7 +33,7 @@ jobs:
       FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
-      ADMINS: ${{ secrets.OWNERS }}
+      ADMINS: 'meganrm, toloudis' #${{ secrets.OWNERS }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -33,7 +33,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: ${{ (github.ref == 'refs/heads/main') && contains(${{$env.ADMINS}}, ${{ github.triggering_actor }}) }}
+    if: ${{ (github.ref == 'refs/heads/main') && contains(${{env.ADMINS}}, ${{ github.triggering_actor }}) }}
     # env:
     #   NODE_ENV: ${{ github.event.inputs.database }}
     #   STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -20,20 +20,19 @@ on:
         - production
 
 jobs:
-  # build:
-  #   name: Build
-  #   runs-on: ubuntu-latest         
-  #   outputs:
-  #     stageEnv: ${{ steps.init.outputs.ADMINS }}
-    
-  #   steps:        
-  #     - name: Make environment variables global 
-  #       id: init
-  #       run: |
-  #         echo "stageEnv=${{ env.ADMINS }}" >> $GITHUB_OUTPUT
+  check_user:
+    name: Authorization Check
+    runs-on: ubuntu-latest
+    outputs:
+      authorized-users: ${{ steps.check.outputs.ADMINS }}
+    steps: 
+      - id: check
+        env:
+          ADMINS: ${{ secrets.OWNERS }}
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
+    needs: [check_user]
     env:
       NODE_ENV: ${{ github.event.inputs.database }}
       STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}
@@ -42,8 +41,8 @@ jobs:
       FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
-      ADMINS: ${{ secrets.OWNERS }}
-    if: contains($ADMINS, github.triggering_actor)
+      # ADMINS: ${{ secrets.OWNERS }}
+    if: contains(needs.check_user.outputs.authorized-users, github.triggering_actor)
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
@@ -59,6 +58,6 @@ jobs:
         run: |
           echo "${{ github.triggering_actor }}"
           echo "${{ github.actor }}"
-          echo "$ADMINS"
           echo "${{ github.ref }}"
+          echo "${{ steps.check.outputs.ADMINS }}"
 

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -22,7 +22,6 @@ on:
 
 jobs:
   release_dataset: 
-    if: github.ref == 'refs/heads/main' && contains($ADMINS, ${{ github.triggering_actor }})
     name: Release Dataset
     runs-on: ubuntu-latest
     env:
@@ -34,6 +33,7 @@ jobs:
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
       ADMINS: "meganrm, toloudis"
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -46,7 +46,7 @@ jobs:
     name: Release Dataset
     runs-on: ubuntu-latest
     # if: ${{ env.ADMINTEST == github.triggering_actor }}
-    if: (github.ref == 'refs/heads/main') && contains(needs.build.outputs.stageEnv, ${{ github.triggering_actor }})
+    if: ${{ (github.ref == 'refs/heads/main') && contains(needs.build.outputs.stageEnv, github.triggering_actor) }}
     # env:
     #   NODE_ENV: ${{ github.event.inputs.database }}
     #   STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -18,8 +18,23 @@ on:
         options: 
         - staging
         - production
-      
-env:
+
+jobs:
+  # build:
+  #   name: Build
+  #   runs-on: ubuntu-latest         
+  #   outputs:
+  #     stageEnv: ${{ steps.init.outputs.ADMINS }}
+    
+  #   steps:        
+  #     - name: Make environment variables global 
+  #       id: init
+  #       run: |
+  #         echo "stageEnv=${{ env.ADMINS }}" >> $GITHUB_OUTPUT
+  release_dataset: 
+    name: Release Dataset
+    runs-on: ubuntu-latest
+    env:
       NODE_ENV: ${{ github.event.inputs.database }}
       STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}
       STAGING_FIREBASE_EMAIL: ${{ secrets.STAGING_FIREBASE_EMAIL }}
@@ -28,34 +43,7 @@ env:
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
       ADMINS: ${{ secrets.OWNERS }}
-      ADMINTEST: "string"
-
-jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest         
-    outputs:
-      stageEnv: ${{ steps.init.outputs.ADMINS }}
-    
-    steps:        
-      - name: Make environment variables global 
-        id: init
-        run: |
-          echo "stageEnv=${{ env.ADMINS }}" >> $GITHUB_OUTPUT
-  release_dataset: 
-    name: Release Dataset
-    runs-on: ubuntu-latest
-    # if: ${{ env.ADMINTEST == github.triggering_actor }}
-    if: ${{ contains(needs.build.outputs.stageEnv, github.triggering_actor) }}
-    # env:
-    #   NODE_ENV: ${{ github.event.inputs.database }}
-    #   STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}
-    #   STAGING_FIREBASE_EMAIL: ${{ secrets.STAGING_FIREBASE_EMAIL }}
-    #   FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-    #   FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
-    #   AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
-    #   AWS_ID: ${{ secrets.CFE_AWS_ID }}
-    #   ADMINS: ${{ secrets.OWNERS }}
+    if: ${{ contains($ADMINS, github.triggering_actor) }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
@@ -70,6 +58,6 @@ jobs:
       - name: debug
         run: |
           echo "${{ github.triggering_actor }}"
-          echo "${{ env.ADMINS }}"
+          echo "${{ $ADMINS }}"
           echo "${{ github.ref }}"
 

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -27,7 +27,7 @@ env:
       FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
-      ADMINS: "meganrm, rugeli, toloudis" #${{ secrets.OWNERS }}
+      ADMINS: "meganrm, toloudis" #${{ secrets.OWNERS }}
 
 
 jobs:

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -19,6 +19,16 @@ on:
         - staging
         - production
 
+env:
+      NODE_ENV: ${{ github.event.inputs.database }}
+      STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}
+      STAGING_FIREBASE_EMAIL: ${{ secrets.STAGING_FIREBASE_EMAIL }}
+      FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+      FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
+      AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
+      AWS_ID: ${{ secrets.CFE_AWS_ID }}
+      ADMINS: ${{ secrets.OWNERS }} # meganrm, rugeli, toloudis
+
 jobs:
   check_user:
     name: Authorization Check
@@ -29,7 +39,7 @@ jobs:
       - name: Make env variable ADMINS global
         id: check
         run: | 
-          echo "ADMINS=${{ secrets.OWNERS }}" >> $GITHUB_OUTPUT
+          echo "ADMINS=${{ env.ADMINS }}" >> $GITHUB_OUTPUT
           echo "${{ steps.check.outputs.ADMINS }}" 
         # echo ${{ steps.check.outputs.ADMINS }} == ""
         
@@ -37,15 +47,6 @@ jobs:
     name: Release Dataset
     runs-on: ubuntu-latest
     needs: [check_user]
-    env:
-      NODE_ENV: ${{ github.event.inputs.database }}
-      STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}
-      STAGING_FIREBASE_EMAIL: ${{ secrets.STAGING_FIREBASE_EMAIL }}
-      FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-      FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
-      AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
-      AWS_ID: ${{ secrets.CFE_AWS_ID }}
-      # ADMINS: ${{ secrets.OWNERS }} # meganrm, rugeli, toloudis
     if: contains(needs.check_user.outputs.ADMINS, github.triggering_actor) #&& github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -27,7 +27,7 @@ env:
       FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
-      ADMINS: "meganrm, toloudis" #${{ secrets.OWNERS }}
+      ADMINS: '["meganrm", "toloudis"]' #${{ secrets.OWNERS }}
 
 
 jobs:
@@ -47,16 +47,18 @@ jobs:
     name: Release Dataset
     runs-on: ubuntu-latest
     # needs: [check_user]
-    if: contains(env.ADMINS, github.triggering_actor) #&& github.ref == 'refs/heads/main'
+    # if:  github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
-      - run: npm ci
-      # - name: Release dataset
+      # - run: npm ci
+      - name: Release dataset
+        if: contains(env.ADMINS, github.triggering_actor)
       #   run: npm run release-dataset ${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }}
+        run: echo "would run"
       - name: specify database 
         run: echo "${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }} is successfully released to ${{ github.event.inputs.database }} database."
       - name: debug

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -24,16 +24,13 @@ jobs:
     name: Authorization Check
     runs-on: ubuntu-latest
     outputs:
-      authorized-users: ${{ steps.check.outputs.ADMINS }}
+      ADMINS: ${{ steps.check.outputs.ADMINS }}
     steps: 
-      - id: check
-      - uses: actions/checkout@v3
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.x
-        env:
-          ADMINS: ${{ secrets.OWNERS }}
+      - name: Make env variable ADMINS global
+        id: check
+        run: | 
+          echo "ADMINS=${{ env.ADMINS }}" >> $GITHUB_OUTPUT
+        
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
@@ -46,8 +43,8 @@ jobs:
       FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
-      # ADMINS: ${{ secrets.OWNERS }}
-    if: contains(needs.check_user.outputs.authorized-users, github.triggering_actor)
+      ADMINS: ${{ secrets.OWNERS }}
+    if: contains(needs.check_user.outputs.ADMINS, github.triggering_actor)
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -43,7 +43,7 @@ jobs:
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
       ADMINS: ${{ secrets.OWNERS }}
-    if: ${{ contains($ADMINS, github.triggering_actor) }}
+    if: contains(env.ADMINS, github.triggering_actor)
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
@@ -58,6 +58,7 @@ jobs:
       - name: debug
         run: |
           echo "${{ github.triggering_actor }}"
+          echo "${{ github.actor }}"
           echo "${{ $ADMINS }}"
           echo "${{ github.ref }}"
 

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -33,7 +33,7 @@ jobs:
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
       ADMINS: "meganrm, toloudis"
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && contains(split(env.ADMINS, ','), github.actor) #working, next step -- only admins can run e.g. && contains($ADMINS, ${{ github.triggering_actor }}) 
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -33,7 +33,7 @@ jobs:
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
       ADMINS: "meganrm, toloudis"
-    if: contains('${{ env.ADMINS }}', github.actor)
+    if: contains('${{ ADMINS }}', github.actor)
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -33,7 +33,7 @@ jobs:
       FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
-      ADMINS: "meganrm", "toloudis" #${{ secrets.OWNERS }}
+      ADMINS: "meganrm, toloudis" #${{ secrets.OWNERS }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
@@ -45,9 +45,5 @@ jobs:
         run: npm run release-dataset ${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }}
       - name: specify database 
         run: echo "${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }} is successfully released to ${{ github.event.inputs.database }} database."
-      - name: test
-        run: echo "${{ github.triggering_actor }}"
-      - name: admins
-        run: echo "${{ env.ADMINS }}"
       
 

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -33,7 +33,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: ${{ (github.ref == 'refs/heads/main') && contains(${{$ADMINS}}, ${{ github.triggering_actor }}) }}
+    if: ${{ (github.ref == 'refs/heads/main') && contains(${{$env.ADMINS}}, ${{ github.triggering_actor }}) }}
     # env:
     #   NODE_ENV: ${{ github.event.inputs.database }}
     #   STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Make environment variables global 
         id: init
         run: |
-          echo "stageEnv=${{ env.stageEnv }}" >> $GITHUB_OUTPUT
+          echo "stageEnv=${{ env.ADMINS }}" >> $GITHUB_OUTPUT
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -27,27 +27,14 @@ env:
       FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
-      ADMINS: '["meganrm", "toloudis"]' #${{ secrets.OWNERS }}
+      ADMINS: ${{ secrets.OWNERS }} #'["meganrm", "toloudis"]' 
 
 
-jobs:
-  # check_user:
-  #   name: Authorization Check
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     admins: ${{ steps.check.outputs.admins }}
-  #   steps: 
-  #     - name: Env variable ADMINS to output
-  #       id: check
-  #       run: | 
-  #         echo "admins=${{ env.ADMINS }}" >> $GITHUB_OUTPUT
-  #         echo "${{ steps.check.outputs.admins }}" 
-        
+jobs:     
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    # needs: [check_user]
-    # if:  github.ref == 'refs/heads/main'
+    if:  github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -1,4 +1,4 @@
-name: Release dataset to production DB
+name: Release dataset to staging or production DB
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -24,7 +24,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: contains($ADMIN, ${{ github.triggering_actor }})
+    if: contains($ADMINS, ${{ github.triggering_actor }})
     env:
       NODE_ENV: ${{ github.event.inputs.database }}
       STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}
@@ -33,7 +33,7 @@ jobs:
       FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
-      ADMIN: "meganrm", "toloudis1" #${{ secrets.OWNERS }}
+      ADMINS: "meganrm", "toloudis" #${{ secrets.OWNERS }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
@@ -48,6 +48,6 @@ jobs:
       - name: test
         run: echo "${{ github.triggering_actor }}"
       - name: admins
-        run: echo "${{ env.ADMIN }}"
+        run: echo "${{ env.ADMINS }}"
       
 

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -46,7 +46,7 @@ jobs:
     name: Release Dataset
     runs-on: ubuntu-latest
     # if: ${{ env.ADMINTEST == github.triggering_actor }}
-    if: ${{ (github.ref == 'refs/heads/main') && contains(needs.build.outputs.stageEnv, github.triggering_actor) }}
+    if: ${{ contains(needs.build.outputs.stageEnv, github.triggering_actor) }}
     # env:
     #   NODE_ENV: ${{ github.event.inputs.database }}
     #   STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -24,7 +24,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && contains($ADMINS, ${{ github.triggering_actor }})
+    if: (github.ref == 'refs/heads/main') && contains($ADMINS, ${{ github.triggering_actor }})
     env:
       NODE_ENV: ${{ github.event.inputs.database }}
       STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -24,7 +24,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: contains(fromJson(env.ADMINS, ${{ github.triggering_actor }})
+    if: contains(fromJson(env.ADMINS), ${{ github.triggering_actor }})
     env:
       NODE_ENV: ${{ github.event.inputs.database }}
       STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}
@@ -45,5 +45,9 @@ jobs:
         run: npm run release-dataset ${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }}
       - name: specify database 
         run: echo "${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }} is successfully released to ${{ github.event.inputs.database }} database."
+      - name: test
+        run: echo "${{ github.triggering_actor }}"
+      - name: admins
+        run: echo "${{ env.ADMINS }}"
       
 

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -57,6 +57,6 @@ jobs:
       - name: debug
         run: |
           echo "${{ github.triggering_actor }}"
-          echo "$ADMINS"
+          echo "${{ env.ADMINS }}"
           echo "${{ github.ref }}"
 

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -33,7 +33,7 @@ jobs:
       FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
-      ADMINS: "meganrm, toloudis" #${{ secrets.OWNERS }}
+      ADMINS: ${{ secrets.OWNERS }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
@@ -45,5 +45,6 @@ jobs:
         run: npm run release-dataset ${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }}
       - name: specify database 
         run: echo "${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }} is successfully released to ${{ github.event.inputs.database }} database."
-      
+      - name: admins
+        run: echo "${{ env.ADMINS }}"
 

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -33,7 +33,7 @@ jobs:
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
       ADMINS: "meganrm, toloudis"
-    if: contains(split(env.ADMINS, ','), github.actor) 
+    if: contains($ADMINS, ${{ github.triggering_actor }})
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -27,6 +27,11 @@ jobs:
       authorized-users: ${{ steps.check.outputs.ADMINS }}
     steps: 
       - id: check
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
         env:
           ADMINS: ${{ secrets.OWNERS }}
   release_dataset: 

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -27,29 +27,23 @@ env:
       FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
       AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
       AWS_ID: ${{ secrets.CFE_AWS_ID }}
-      ADMINS: ${{ secrets.OWNERS }} #'["meganrm", "toloudis"]' 
+      ADMINS: ${{ secrets.OWNERS }}
 
 
 jobs:     
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    # if:  github.ref == 'refs/heads/main'
+    if:  github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
-      # - run: npm ci
+      - run: npm ci
       - name: Release dataset
         if: contains(env.ADMINS, github.triggering_actor)
-      #   run: npm run release-dataset ${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }}
-        run: echo "would run"
+        run: npm run release-dataset ${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }}
       - name: specify database 
         run: echo "${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }} is successfully released to ${{ github.event.inputs.database }} database."
-      - name: debug
-        run: |
-          echo "${{ github.triggering_actor }}"
-          echo "${{ github.ref }}"
-          echo "${{ env.ADMINS }}"

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -33,7 +33,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: (github.ref == 'refs/heads/main') && contains(${{ secrets.OWNERS }}, ${{ github.triggering_actor }})
+    if: (github.ref == 'refs/heads/main') && contains($secrets.OWNERS, ${{ github.triggering_actor }})
     # env:
     #   NODE_ENV: ${{ github.event.inputs.database }}
     #   STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -31,11 +31,22 @@ env:
       ADMINTEST: "string"
 
 jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest         
+    outputs:
+      stageEnv: ${{ steps.init.outputs.ADMINS }}
+    
+    steps:        
+      - name: Make environment variables global 
+        id: init
+        run: |
+          echo "stageEnv=${{ env.stageEnv }}" >> $GITHUB_OUTPUT
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if: ${{ env.ADMINTEST == github.triggering_actor }}
-    # if: (github.ref == 'refs/heads/main') && contains($ADMINTEST, ${{ github.triggering_actor }})
+    # if: ${{ env.ADMINTEST == github.triggering_actor }}
+    if: (github.ref == 'refs/heads/main') && contains(needs.build.outputs.stageEnv, ${{ github.triggering_actor }})
     # env:
     #   NODE_ENV: ${{ github.event.inputs.database }}
     #   STAGING_FIREBASE_TOKEN: ${{ secrets.STAGING_FIREBASE_TOKEN }}


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #56 

Solution
========
What I/we did to solve this problem
- created a new manually triggered workflow that will run `release-data`, only on `main`
- Inputs include: `megaset-name`, `dataset-id` and `database`
- added a new github repo secret `owners`, so only authorized users are able to trigger this action  

with @meganrm 

## Type of change
Please delete options that are not relevant.
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Go to Actions  and choose `Release dataset to production DB` in workflows 
2. Click on `Run Workflow` and select `feature/publish-to-production` branch for testing. Note that the job is expected to be skipped on a non-main branch, comment out `if:  github.ref == 'refs/heads/main'` to run the job
3. Enter inputs and stay with default `staging` database for testing
4. Run workflow 