### PR TITLE
Feature/add an admin check to release dataset workflow 

### DIFF
--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -53,7 +53,7 @@ jobs:
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    # if:  github.ref == 'refs/heads/main'
+    if:  github.ref == 'refs/heads/main'
     needs: get_admins
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release-dataset.yml
+++ b/.github/workflows/release-dataset.yml
@@ -27,14 +27,34 @@ env:
   FIREBASE_EMAIL: ${{ secrets.FIREBASE_EMAIL }}
   AWS_SECRET: ${{ secrets.CFE_AWS_SECRET }}
   AWS_ID: ${{ secrets.CFE_AWS_ID }}
-  ADMINS: ${{ secrets.OWNERS }}
 
 
-jobs:     
+jobs: 
+  get_admins:
+    runs-on: ubuntu-latest
+    outputs:
+      collaborators: ${{ steps.check_collaborator.outputs.collaborators }}
+    steps:
+      - name: Get collaborators
+        id: check_collaborator
+        run: |
+          response=$(curl --request GET \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            --url https://api.github.com/repos/${{ github.repository }}/collaborators \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            --header 'content-type: application/json')
+          collaborators=$(echo "$response" | jq -r '.[] | select(.permissions.admin == true) | .login')
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "collaborators<<$EOF" >> $GITHUB_OUTPUT
+          echo "$collaborators" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+
   release_dataset: 
     name: Release Dataset
     runs-on: ubuntu-latest
-    if:  github.ref == 'refs/heads/main'
+    # if:  github.ref == 'refs/heads/main'
+    needs: get_admins
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node
@@ -43,10 +63,10 @@ jobs:
           node-version: 16.x
       - run: npm ci
       - name: Release dataset
-        if: contains(env.ADMINS, github.triggering_actor)
+        if: contains(needs.get_admins.outputs.collaborators, github.triggering_actor)
         run: |
           npm run release-dataset ${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }}
           echo "${{ github.event.inputs.megaset-name }} ${{ github.event.inputs.dataset-id }} is successfully released to ${{ github.event.inputs.database }} database."
       - name: Not authorized to release dataset
-        if: ${{ !contains(env.ADMINS, github.triggering_actor) }}
+        if: ${{ !contains(needs.get_admins.outputs.collaborators, github.triggering_actor) }}
         run: echo "Failed to release dataset. Please contact the owner of the repository to obtain the permission."


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including

Similarly to the changes in `upload_dataset.yml`, we can retrieve the admin list from github repo to check authorization instead of using github secrets in `release_dataset.yml`, we want to remove the github secret for owners and instead use github `Collaborators and Teams` to verify the authorization of each user. 

Solution
========
What I/we did to solve this problem
- added a job named `get_admins` that calls the github api to retrieve collaborators who have admin access to the repo 
- removed secrets.OWNERS, which was previously used to verify user authorization   


## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)