### PR TITLE
Update check-input-datasets.js

### DIFF
--- a/bin/check-input-datasets.js
+++ b/bin/check-input-datasets.js
@@ -97,7 +97,6 @@ const validateDatasets = () => {
         throw Error("Validation failed");
       }
     })
-    .catch(console.log);
 };
 
 validateDatasets();


### PR DESCRIPTION
don't want to catch the final error, if there was an error, the action should fail

Problem
=======
the drug data set had an error but the action still exited as passed 

Solution
========
removed the final catch

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)



Steps to Verify:
----------------
1. once we merge this, the drug dataset should fail (until it's fixed)


