### PR TITLE
Feature/keys validation

### DIFF
--- a/bin/check-input-datasets.js
+++ b/bin/check-input-datasets.js
@@ -6,7 +6,7 @@ const { DATA_FOLDER_NAME } = require("../src/process-single-dataset/constants");
 const { readDatasetJson } = require("../src/utils");
 const dataPrep = require("../src/data-validation/data-prep");
 const unpackInputDataset = require("../src/data-validation/unpack-input-dataset");
-
+const {validateFeatureDataKeys} = require("../src/utils");
 // referenced partial schemas
 const INPUT_DATASET_SCHEMA_FILE = "input-dataset.schema.json";
 const INPUT_MEGASET_SCHEMA_FILE = "input-megaset.schema.json";
@@ -22,23 +22,10 @@ const checkForError = (fileName, json, schemaFileName) => {
   if (json["feature-defs"]) {
     const featuresDataOrder = json.dataset.featuresDataOrder;
     const featureDefsData = json["feature-defs"];
-    const keyList = Array.from(
-      featureDefsData,
-      (featureDataJson) => featureDataJson.key
-    );
-    if (featuresDataOrder.length > keyList.length) {
-      keysErrorMsg =
-        `featureDefs has ${keyList.length} features but there are ${featuresDataOrder.length} listed in featuresDataOrder`;
-      featureKeysError = true;
-    }
-    featuresDataOrder.forEach((keyName) => {
-      if (!keyList.includes(keyName)) {
-        keysErrorMsg =
-          `key ${keyName} in featuresDataOrder does not exist in featureDefs`;
-        featureKeysError = true;
-      }
-    });
-  }
+    const result = validateFeatureDataKeys( featuresDataOrder, featureDefsData );
+    featureKeysError = result.featureKeysError;
+    keysErrorMsg = result.keysErrorMsg;
+  };
 
   if (!valid || featureKeysError) {
     console.log(

--- a/bin/check-input-datasets.js
+++ b/bin/check-input-datasets.js
@@ -17,12 +17,35 @@ const checkForError = (fileName, json, schemaFileName) => {
     json,
     ajv.getSchema(schemaFileName)
   );
-  if (!valid) {
+  let featureKeysError = false;
+  let keysErrorMsg = "";
+  if (json["feature-defs"]) {
+    const featuresDataOrder = json.dataset.featuresDataOrder;
+    const featureDefsData = json["feature-defs"];
+    const keyList = Array.from(
+      featureDefsData,
+      (featureDataJson) => featureDataJson.key
+    );
+    if (featuresDataOrder.length > keyList.length) {
+      keysErrorMsg =
+        `featureDefs has ${keyList.length} features but there are ${featuresDataOrder.length} listed in featuresDataOrder`;
+      featureKeysError = true;
+    }
+    featuresDataOrder.forEach((keyName) => {
+      if (!keyList.includes(keyName)) {
+        keysErrorMsg =
+          `key ${keyName} in featuresDataOrder does not exist in featureDefs`;
+        featureKeysError = true;
+      }
+    });
+  }
+
+  if (!valid || featureKeysError) {
     console.log(
       "\x1b[0m",
       `${fileName}`,
       "\x1b[31m",
-      `failed because: ${JSON.stringify(error)}`,
+      `failed because: ${JSON.stringify(error || keysErrorMsg)}`,
       "\x1b[0m"
     );
     return true;
@@ -96,7 +119,7 @@ const validateDatasets = () => {
         console.log("\x1b[31m");
         throw Error("Validation failed");
       }
-    })
+    });
 };
 
 validateDatasets();

--- a/src/process-single-dataset/index.js
+++ b/src/process-single-dataset/index.js
@@ -42,6 +42,18 @@ const processSingleDataset = async (
     datasetJson.featuresDataOrder.indexOf(defaultGroupBy);
 
   const featureDefsData = await readFeatureData();
+  const featuresDataOrder = datasetJson.featuresDataOrder;
+  if (featuresDataOrder.length > featureDefsData.length) {
+    console.error("Error: Too many features in featuresDataOrder");
+    process.exit(1);
+  }
+  const keyList = Array.from(featureDefsData, (featureDataJson) => featureDataJson.key);
+  featuresDataOrder.forEach((keyName) => {
+    if (!keyList.includes(keyName)) {
+      console.error(`Error: key ${keyName} not found`);
+      process.exit(1);
+    }
+  });
 
   const TEMP_FOLDER = "./tmp/" + id;
 

--- a/src/process-single-dataset/index.js
+++ b/src/process-single-dataset/index.js
@@ -44,13 +44,15 @@ const processSingleDataset = async (
   const featureDefsData = await readFeatureData();
   const featuresDataOrder = datasetJson.featuresDataOrder;
   if (featuresDataOrder.length > featureDefsData.length) {
-    console.error("Error: Too many features in featuresDataOrder");
+    console.error(`Error: featureDefs has ${featureDefsData.length} features but there are ${featuresDataOrder.length} listed in featuresDataOrder`);
     process.exit(1);
   }
   const keyList = Array.from(featureDefsData, (featureDataJson) => featureDataJson.key);
   featuresDataOrder.forEach((keyName) => {
     if (!keyList.includes(keyName)) {
-      console.error(`Error: key ${keyName} not found`);
+      console.error(
+        `Error: key ${keyName} in featuresDataOrder does not exist in featureDefs`
+      );
       process.exit(1);
     }
   });

--- a/src/process-single-dataset/index.js
+++ b/src/process-single-dataset/index.js
@@ -7,6 +7,7 @@ const uploadFileInfo = require("./steps/upload-file-info");
 const uploadFeaturesFileToS3 = require("./steps/upload-features-to-aws");
 const uploadFileToS3 = require("./steps/upload-file-to-aws");
 const uploadDatasetImage = require("./steps/upload-dataset-image");
+const {validateFeatureDataKeys} = require("../utils");
 
 const FirebaseHandler = require("../firebase/firebase-handler");
 
@@ -43,19 +44,11 @@ const processSingleDataset = async (
 
   const featureDefsData = await readFeatureData();
   const featuresDataOrder = datasetJson.featuresDataOrder;
-  if (featuresDataOrder.length > featureDefsData.length) {
-    console.error(`Error: featureDefs has ${featureDefsData.length} features but there are ${featuresDataOrder.length} listed in featuresDataOrder`);
+  const { featureKeysError, keysErrorMsg } = validateFeatureDataKeys(featuresDataOrder, featureDefsData); 
+  if (featureKeysError) {
+    console.error(keysErrorMsg);
     process.exit(1);
   }
-  const keyList = Array.from(featureDefsData, (featureDataJson) => featureDataJson.key);
-  featuresDataOrder.forEach((keyName) => {
-    if (!keyList.includes(keyName)) {
-      console.error(
-        `Error: key ${keyName} in featuresDataOrder does not exist in featureDefs`
-      );
-      process.exit(1);
-    }
-  });
 
   const TEMP_FOLDER = "./tmp/" + id;
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -48,12 +48,14 @@ const validateFeatureDataKeys = (featuresDataOrder, featureDefs) => {
         keysErrorMsg = 
             `Error: featureDefs has ${keyList.length} features but there are ${featuresDataOrder.length} listed in featuresDataOrder`;
         featureKeysError = true;
+        return { featureKeysError, keysErrorMsg };
     };
     featuresDataOrder.forEach((keyName) => {
         if (!keyList.includes(keyName)) {
             keysErrorMsg =
                 `Error: key ${keyName} in featuresDataOrder does not exist in featureDefs`;
             featureKeysError = true;
+            return { featureKeysError, keysErrorMsg };
         }
     });
     return { featureKeysError, keysErrorMsg };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -40,8 +40,28 @@ const readPossibleZippedFile = async (folder, fileName) => {
     return parsedData;
 }
 
+const validateFeatureDataKeys = (featuresDataOrder, featureDefs) => {
+    let featureKeysError = false;
+    let keysErrorMsg = "";
+    const keyList = Array.from(featureDefs, (featureDataJson) => featureDataJson.key);
+    if (featuresDataOrder.length > keyList.length) {
+        keysErrorMsg = 
+            `Error: featureDefs has ${keyList.length} features but there are ${featuresDataOrder.length} listed in featuresDataOrder`;
+        featureKeysError = true;
+    };
+    featuresDataOrder.forEach((keyName) => {
+        if (!keyList.includes(keyName)) {
+            keysErrorMsg =
+                `Error: key ${keyName} in featuresDataOrder does not exist in featureDefs`;
+            featureKeysError = true;
+        }
+    });
+    return { featureKeysError, keysErrorMsg };
+};
+
 module.exports = {
     readDatasetJson,
     readAndParseFile, 
-    readPossibleZippedFile
+    readPossibleZippedFile,
+    validateFeatureDataKeys
 }


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #74 

Solution
========
What I/we did to solve this problem
added a function to validate keys in featuresDataOrder, and used in `check-input-datasets.js` and "process-single-datasets"

Expected behaviors
========
Error if: 1. `featuresDataOrder` contains keys not found in featureDefs.json
2. if the length of the list is longer than the number of features in the measured feature data per image

Both commands -- `npm run process-dataset` and `npm run validate-datasets` should fail

<img width="1064" alt="Screenshot 2023-05-03 at 2 10 29 PM" src="https://user-images.githubusercontent.com/91452427/236051931-f8424701-b8e5-4544-8f97-d204550ab98d.png">

<img width="1132" alt="Screenshot 2023-05-03 at 2 10 42 PM" src="https://user-images.githubusercontent.com/91452427/236051961-0ee9a73e-2c5f-46f9-9894-e34a45dbd190.png">

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Change or add a key in `featuresDataOrder` array for testing 
2. Run `npm run validate-datasets` and `npm run process-dataset [DATASET-PATH] true` to see the errors



