### PR TITLE
Feature/user data validation

### DIFF
--- a/bin/check-input-datasets.js
+++ b/bin/check-input-datasets.js
@@ -17,14 +17,14 @@ const checkForError = (fileName, json, schemaFileName) => {
     ajv.getSchema(schemaFileName)
   );
   let datasetsError = false;
-  let ErrorMsg = "";
+  let errorMsg = "";
   if (json["feature-defs"]) {
     const featuresDataOrder = json.dataset.featuresDataOrder;
     const featureDefsData = json["feature-defs"];
     const result = utils.validateFeatureDataKeys( featuresDataOrder, featureDefsData );
     if (result.featureKeysError) {
       datasetsError = result.featureKeysError;
-      ErrorMsg = result.keysErrorMsg;
+      errorMsg = result.keysErrorMsg;
     };
   };
   if (json["dataset"]) {
@@ -33,7 +33,7 @@ const checkForError = (fileName, json, schemaFileName) => {
     const result = utils.validateUserDataValues( totalCells, totalFOVs );
     if (result.userDataError) {
       datasetsError = result.userDataError;
-      ErrorMsg = result.userDataErrorMsg;
+      errorMsg = result.userDataErrorMsg;
     };  
   };
 
@@ -43,7 +43,7 @@ const checkForError = (fileName, json, schemaFileName) => {
       "\x1b[0m",
       `${fileName}`,
       "\x1b[31m",
-      `failed because: ${JSON.stringify(error || ErrorMsg)}`,
+      `failed because: ${JSON.stringify(error || errorMsg)}`,
       "\x1b[0m"
     );
     return true;

--- a/bin/check-input-datasets.js
+++ b/bin/check-input-datasets.js
@@ -3,10 +3,9 @@ const {
   getInputDatasetSchema,
 } = require("../src/data-validation/get-input-dataset-schema");
 const { DATA_FOLDER_NAME } = require("../src/process-single-dataset/constants");
-const { readDatasetJson } = require("../src/utils");
+const utils = require("../src/utils");
 const dataPrep = require("../src/data-validation/data-prep");
 const unpackInputDataset = require("../src/data-validation/unpack-input-dataset");
-const {validateFeatureDataKeys} = require("../src/utils");
 // referenced partial schemas
 const INPUT_DATASET_SCHEMA_FILE = "input-dataset.schema.json";
 const INPUT_MEGASET_SCHEMA_FILE = "input-megaset.schema.json";
@@ -17,22 +16,34 @@ const checkForError = (fileName, json, schemaFileName) => {
     json,
     ajv.getSchema(schemaFileName)
   );
-  let featureKeysError = false;
-  let keysErrorMsg = "";
+  let datasetsError = false;
+  let ErrorMsg = "";
   if (json["feature-defs"]) {
     const featuresDataOrder = json.dataset.featuresDataOrder;
     const featureDefsData = json["feature-defs"];
-    const result = validateFeatureDataKeys( featuresDataOrder, featureDefsData );
-    featureKeysError = result.featureKeysError;
-    keysErrorMsg = result.keysErrorMsg;
+    const result = utils.validateFeatureDataKeys( featuresDataOrder, featureDefsData );
+    if (result.featureKeysError) {
+      datasetsError = result.featureKeysError;
+      ErrorMsg = result.keysErrorMsg;
+    };
+  };
+  if (json["dataset"]) {
+    const totalCells = json.dataset.userData.totalCells;
+    const totalFOVs = json.dataset.userData.totalFOVs;
+    const result = utils.validateUserDataValues( totalCells, totalFOVs );
+    if (result.userDataError) {
+      datasetsError = result.userDataError;
+      ErrorMsg = result.userDataErrorMsg;
+    };  
   };
 
-  if (!valid || featureKeysError) {
+
+  if (!valid || datasetsError) {
     console.log(
       "\x1b[0m",
       `${fileName}`,
       "\x1b[31m",
-      `failed because: ${JSON.stringify(error || keysErrorMsg)}`,
+      `failed because: ${JSON.stringify(error || ErrorMsg)}`,
       "\x1b[0m"
     );
     return true;
@@ -79,7 +90,7 @@ const validateDatasets = () => {
         }
       }
       for (const datasetFolder of foldersToCheck) {
-        const topLevelJson = await readDatasetJson(datasetFolder);
+        const topLevelJson = await utils.readDatasetJson(datasetFolder);
         if (topLevelJson.datasets) {
           // is a megaset, need to check both megaset
           // file and each dataset folder

--- a/src/process-single-dataset/index.js
+++ b/src/process-single-dataset/index.js
@@ -1,5 +1,5 @@
 const fsPromises = require("fs").promises;
-const { readAndParseFile } = require("../utils");
+const utils = require("../utils");
 const uploadManifest = require("./steps/upload-manifest");
 const uploadFeatureDefs = require("./steps/upload-feature-defs");
 const formatAndWritePerCellJsons = require("./steps/write-per-cell-jsons");
@@ -7,7 +7,6 @@ const uploadFileInfo = require("./steps/upload-file-info");
 const uploadFeaturesFileToS3 = require("./steps/upload-features-to-aws");
 const uploadFileToS3 = require("./steps/upload-file-to-aws");
 const uploadDatasetImage = require("./steps/upload-dataset-image");
-const {validateFeatureDataKeys} = require("../utils");
 
 const FirebaseHandler = require("../firebase/firebase-handler");
 
@@ -34,7 +33,7 @@ const processSingleDataset = async (
     }
   }
   const readFeatureData = async () => {
-    return await readAndParseFile(
+    return await utils.readAndParseFile(
       `${datasetReadFolder}/${fileNames.featureDefs}`
     );
   };
@@ -44,11 +43,18 @@ const processSingleDataset = async (
 
   const featureDefsData = await readFeatureData();
   const featuresDataOrder = datasetJson.featuresDataOrder;
-  const { featureKeysError, keysErrorMsg } = validateFeatureDataKeys(featuresDataOrder, featureDefsData); 
+  const { featureKeysError, keysErrorMsg } = utils.validateFeatureDataKeys(featuresDataOrder, featureDefsData); 
   if (featureKeysError) {
     console.error(keysErrorMsg);
     process.exit(1);
-  }
+  };
+  const totalCells = datasetJson.userData.totalCells;
+  const totalFOVs = datasetJson.userData.totalFOVs;
+  const {userDataError, userDataErrorMsg} = utils.validateUserDataValues(totalCells, totalFOVs);
+  if (userDataError) {
+    console.error(userDataErrorMsg);
+    process.exit(1);
+  };
 
   const TEMP_FOLDER = "./tmp/" + id;
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -61,9 +61,20 @@ const validateFeatureDataKeys = (featuresDataOrder, featureDefs) => {
     return { featureKeysError, keysErrorMsg };
 };
 
+const validateUserDataValues = (totalCells, totalFOVs) => {
+    let userDataError = false;
+    let userDataErrorMsg = "";
+    if (!totalCells && !totalFOVs) {
+        userDataErrorMsg = "Error: totalCells and totalFOVs can't both be zero or undefined";
+        userDataError = true;
+    };
+    return { userDataError, userDataErrorMsg };
+};
+
 module.exports = {
     readDatasetJson,
     readAndParseFile, 
     readPossibleZippedFile,
-    validateFeatureDataKeys
+    validateFeatureDataKeys,
+    validateUserDataValues
 }


### PR DESCRIPTION
Problem
=======

closes #77 

Solution
========
What I/we did to solve this problem 
similar approach to the keys validation:
-added a function to validate values in `userData/totalCells` and `userData/totalFOVs`, and used it in `check-input-datasets.js` and `process-single-datasets`. Will throw an error if both values are zero or if both keys are missing. 


## Type of change
Please delete options that are not relevant.
* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Change the value in the`dataset.json` of a single dataset for testing: modify the values for both `totalCells` and `totalFOVs` in `userData` to zero
2. Run `npm run validate-datasets` and `npm run process-dataset [DATASET-PATH] true` to see the resulting errors

Expected errors: 
-----------------
<img width="1067" alt="Screenshot 2023-05-15 at 11 04 39 AM" src="https://github.com/allen-cell-animated/cell-feature-data/assets/91452427/c545a156-14c1-40ab-8de2-c01e1b4798dd">

<img width="1117" alt="Screenshot 2023-05-15 at 11 05 39 AM" src="https://github.com/allen-cell-animated/cell-feature-data/assets/91452427/0176bfbc-3143-4640-adf8-6b52772c6c02">



