### PR TITLE
error if defaultGroupBy is not discrete

### DIFF
--- a/src/process-single-dataset/steps/write-per-cell-jsons.js
+++ b/src/process-single-dataset/steps/write-per-cell-jsons.js
@@ -52,9 +52,14 @@ const formatAndWritePerCellJsons = async (
     }, {});
 
     const categoryValue = cellData.features[defaultGroupByIndex];
-    const groupBy = find(featureDefs, {
+    const groupByFeature = find(featureDefs, {
       key: defaultGroupBy,
-    }).options[categoryValue];
+    });
+    if (!groupByFeature.discrete || !groupByFeature.options) {
+      console.log(`Error: defaultGroupBy \x1b[33m${defaultGroupBy}\x1b[0m, must be discrete and should have corresponding options`);
+      process.exit(1);
+    };
+    const groupBy = groupByFeature.options[categoryValue];
     if (!groupBy) {
       console.log("NO GROUP BY FOR ", defaultGroupBy, categoryValue);
       process.exit(1);


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
check whether defaultGroupBy is discrete and has `options` before accessing `options`.  

Solution
========
What I/we did to solve this problem
added check in `write-per-cell-jsons.js`, error if defaultGroupBy is not discrete or doesn't have `options` property

with @meganrm 


when run `npm run process-dataset data/dataset-drug-all-continuous-0-1 false`, will hit the error: 
<img width="1147" alt="Screenshot 2023-05-18 at 2 27 17 PM" src="https://github.com/allen-cell-animated/cell-feature-data/assets/91452427/d1789c93-9641-4f7a-97d0-0caf4fe55875">

- we will make another PR to add logging of the current featureName and features in order during `npm run validate-datasets`, so it will be easier for the dataset creator to verify the dataset on their own.  (second thought: we could prioritize #55 and have the featureName oder logs when running single dataset validation)

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)
