### PR TITLE
Feature/feature name index log

### DIFF
--- a/bin/check-single-dataset.js
+++ b/bin/check-single-dataset.js
@@ -80,7 +80,7 @@ const datasetFeatureMap = async (datasetFolder) => {
     toLog[dataOrder[i]] = testCaseFeatures[i];
   }
   console.log(
-    "The current features data order for the first cell in",
+    "The current features data order for the first image in",
     "\x1b[34m",
     `${datasetFolder}:`,
     "\x1b[33m",

--- a/bin/check-single-dataset.js
+++ b/bin/check-single-dataset.js
@@ -15,7 +15,7 @@ const checkForError = (fileName, json, schemaFileName) => {
     ajv.getSchema(schemaFileName)
   );
   let datasetsError = false;
-  let ErrorMsg = "";
+  let errorMsg = "";
   if (json["feature-defs"]) {
     const featuresDataOrder = json.dataset.featuresDataOrder;
     const featureDefsData = json["feature-defs"];
@@ -25,7 +25,7 @@ const checkForError = (fileName, json, schemaFileName) => {
     );
     if (result.featureKeysError) {
       datasetsError = result.featureKeysError;
-      ErrorMsg = result.keysErrorMsg;
+      errorMsg = result.keysErrorMsg;
     }
   }
   if (json["dataset"]) {
@@ -34,7 +34,7 @@ const checkForError = (fileName, json, schemaFileName) => {
     const result = utils.validateUserDataValues(totalCells, totalFOVs);
     if (result.userDataError) {
       datasetsError = result.userDataError;
-      ErrorMsg = result.userDataErrorMsg;
+      errorMsg = result.userDataErrorMsg;
     }
   }
 
@@ -43,7 +43,7 @@ const checkForError = (fileName, json, schemaFileName) => {
       "\x1b[0m",
       `${fileName}`,
       "\x1b[31m",
-      `failed because: ${JSON.stringify(error || ErrorMsg)}`,
+      `failed because: ${JSON.stringify(error || errorMsg)}`,
       "\x1b[0m"
     );
     return true;

--- a/bin/check-single-dataset.js
+++ b/bin/check-single-dataset.js
@@ -4,7 +4,6 @@ const {
 const utils = require("../src/utils");
 const dataPrep = require("../src/data-validation/data-prep");
 const unpackInputDataset = require("../src/data-validation/unpack-input-dataset");
-const { dataset } = require("../src/data-validation/full-schema");
 // referenced partial schemas
 const INPUT_DATASET_SCHEMA_FILE = "input-dataset.schema.json";
 const INPUT_MEGASET_SCHEMA_FILE = "input-megaset.schema.json";
@@ -91,7 +90,7 @@ const datasetFeatureMap = async (datasetFolder) => {
 
   console.log(
     "\x1b[30m", 
-    "If the mapping looks incorrect, please update featuresDataOrder in dataset.json",
+    "If the data looks incorrect, please update featuresDataOrder in dataset.json",
     "\x1b[0m" 
   );
 };

--- a/bin/check-single-dataset.js
+++ b/bin/check-single-dataset.js
@@ -4,6 +4,7 @@ const {
 const utils = require("../src/utils");
 const dataPrep = require("../src/data-validation/data-prep");
 const unpackInputDataset = require("../src/data-validation/unpack-input-dataset");
+const { dataset } = require("../src/data-validation/full-schema");
 // referenced partial schemas
 const INPUT_DATASET_SCHEMA_FILE = "input-dataset.schema.json";
 const INPUT_MEGASET_SCHEMA_FILE = "input-megaset.schema.json";
@@ -71,6 +72,29 @@ const checkSingleDatasetInput = async (datasetFolder) => {
   };
 };
 
+const datasetFeatureMap = async (datasetFolder) => {
+  const inputDataset = await unpackInputDataset(datasetFolder);
+  const dataOrder = inputDataset.dataset.featuresDataOrder;
+  const testCaseFeatures = inputDataset["measured-features"][0].features;
+  const toLog = {};
+  for (let i = 0; i < testCaseFeatures.length; i++) {
+    toLog[dataOrder[i]] = testCaseFeatures[i];
+  }
+  console.log(
+    "The current features data order for the first cell:",
+    "\x1b[33m",
+    JSON.stringify(toLog, null, 2),
+    "\x1b[0m"
+  );
+
+  console.log(
+    "\x1b[30m", 
+    "If the mapping looks incorrect, please update featuresDataOrder in dataset.json",
+    "\x1b[0m" 
+  );
+};
+
+
 const validateSingleDataset = async (datasetFolder) => {
   const topLevelJson = await utils.readDatasetJson(datasetFolder);
   let hasError = false;
@@ -104,6 +128,7 @@ const validateSingleDataset = async (datasetFolder) => {
 if (process.argv[2]) {
   const datasetFolder = process.argv[2];
   validateSingleDataset(datasetFolder);
+  datasetFeatureMap(datasetFolder);
 }
 
 

--- a/bin/check-single-dataset.js
+++ b/bin/check-single-dataset.js
@@ -81,7 +81,9 @@ const datasetFeatureMap = async (datasetFolder) => {
     toLog[dataOrder[i]] = testCaseFeatures[i];
   }
   console.log(
-    "The current features data order for the first cell:",
+    "The current features data order for the first cell in",
+    "\x1b[34m",
+    `${datasetFolder}:`,
     "\x1b[33m",
     JSON.stringify(toLog, null, 2),
     "\x1b[0m"
@@ -95,7 +97,7 @@ const datasetFeatureMap = async (datasetFolder) => {
 };
 
 
-const validateSingleDataset = async (datasetFolder) => {
+const validateSingleDataset = async (datasetFolder, mapFeatures=false) => {
   const topLevelJson = await utils.readDatasetJson(datasetFolder);
   let hasError = false;
   if (topLevelJson.datasets) {
@@ -115,11 +117,17 @@ const validateSingleDataset = async (datasetFolder) => {
       if (foundSubError) {
         hasError = true;
       }
+      if (mapFeatures) {
+        datasetFeatureMap(datasetReadFolder);
+      }
     }
   } else {
     const foundError = await checkSingleDatasetInput(datasetFolder);
     if (foundError) {
       hasError = true;
+    }
+    if (mapFeatures) {
+      datasetFeatureMap(datasetFolder);
     }
   }
   return hasError;
@@ -127,8 +135,8 @@ const validateSingleDataset = async (datasetFolder) => {
 
 if (process.argv[2]) {
   const datasetFolder = process.argv[2];
-  validateSingleDataset(datasetFolder);
-  datasetFeatureMap(datasetFolder);
+  validateSingleDataset(datasetFolder, true);
+  // datasetFeatureMap(datasetFolder, true);
 }
 
 

--- a/bin/check-single-dataset.js
+++ b/bin/check-single-dataset.js
@@ -136,7 +136,6 @@ const validateSingleDataset = async (datasetFolder, mapFeatures=false) => {
 if (process.argv[2]) {
   const datasetFolder = process.argv[2];
   validateSingleDataset(datasetFolder, true);
-  // datasetFeatureMap(datasetFolder, true);
 }
 
 


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
close #81 

Solution
========
What I/we did to solve this problem
- created a function in `check-single-dataset.js` to log a map of the feature names along with their corresponding values, which are from the `cell-feature-analysis` file
- only log the features data when the single validation is run.
- if it's a single dataset - log the single set,  if it's a megaset - log each subset 

An example of the terminal output during the single dataset validation: 

<img width="1113" alt="Screenshot 2023-06-07 at 2 50 33 PM" src="https://github.com/allen-cell-animated/cell-feature-data/assets/91452427/cd898f8e-9ee5-48a3-8f89-7f122b094096">




## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Run `npm run validate-single-dataset [RELATIVE-PATH-OF-SINGLEDATASET-OR-MEGASET]`


Keyfiles (delete if not relevant):
-----------------------
1. `check-input-datasets.js` (some changes are from the previous unmerged PRs)


