### PR TITLE
Feature/gh build docs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,32 @@
+name: Docuemntation
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.x
+    - name: Install Dependencies 
+      run: npm ci
+    - name: Generate Documentation
+      run: |
+        make input-docs
+        make database-docs
+        make convert-to-html
+    - name: Deploy
+      uses: JamesIves/github-pages-deploy-action@3.7.1
+      with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_BRANCH: main
+          PUBLISH_BRANCH: gh-pages
+          FOLDER: docs

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -19,10 +19,7 @@ jobs:
     - name: Install Dependencies 
       run: npm ci
     - name: Generate Documentation
-      run: |
-        make input-docs
-        make database-docs
-        make convert-to-html
+      run: make all-docs
     - name: Deploy
       uses: JamesIves/github-pages-deploy-action@3.7.1
       with:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,4 +1,4 @@
-name: Docuemntation
+name: Documentation
 
 on:
   push:

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ database-docs:
 convert-to-html:
 	$(ASCIIDOCTOR) -D ./dist ${TARGETS}
 
-docs: 
+all-docs: 
 	make input-docs
 	make database-docs
 	make convert-to-html

--- a/docs/HandoffSpecification.adoc
+++ b/docs/HandoffSpecification.adoc
@@ -1,9 +1,9 @@
 = How to hand off a dataset
 
-=== 1. Create the files
+== 1. Create the files
 (the only file names that matters are `dataset.json`)
 
-===== For a single dataset:
+=== For a single dataset:
 [toc]
 
 Create a folder with 5 files:
@@ -14,7 +14,7 @@ Create a folder with 5 files:
 * xref:DatasetHandoffRef.adoc#reference-images[images.json]
 * card-cover.png (for display on the homepage)
 
-===== For a group of datasets, ie a Megaset 
+==== For a group of datasets, ie a Megaset 
 [toc]
 
 Create a folder with 1 file and one folder per dataset.
@@ -32,9 +32,9 @@ Megaset Folder/::
 
 Refer to xref:DatasetHandoffRef.adoc#reference-input-megaset[Megaset] for more information.
 
-=== 2. Make a PR to this repo with your dataset folder. 
+== 2. Make a PR to this repo with your dataset folder. 
 
-= Full Documentation 
+== Full Documentation 
 
 include::DatasetHandoffRef.adoc[]
 :toc: 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "process-dataset": "node bin/process-dataset",
     "upload-image": "node bin/upload-dataset-image",
     "release-dataset": "node bin/release-dataset",
-    "prepublish-docs": "make docs",
+    "prepublish-docs": "make all-docs",
     "publish-docs": "gh-pages -d dist",
     "postpublish-docs": "cd src/data-validation && make clean",
     "validate-datasets": "node bin/check-input-datasets.js"


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
We want to be able to automatically update the documentation when branches merged into main  

Solution
========
What I/we did to solve this problem
- added a workflow in github actions  
- revised the makefile command 
- addressed minor styling issues in `docs/HandoffSpecification.adoc` to eliminate warnings

(there are some remainning warning messages from `asciidoctor` about duplicate IDs, seemed renaming IDs in `DatabaseSchema.adoc` or `DatasetHandoffRef.adoc` is not the correct way to fix them, how do we modify the AsciiDoc files to fix the warnings?)

with @meganrm 

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. check if the build_docs workflow does update documentation when branches merged into main  



