### PR TITLE
validate whether key is required in options

### DIFF
--- a/bin/check-single-dataset.js
+++ b/bin/check-single-dataset.js
@@ -45,15 +45,10 @@ const checkForError = (fileName, json, schemaFileName) => {
       featureDefsData
     );
     if (featureKeysError) return logError(keysErrorMsg);
-
-    for (let featureDef of featureDefsData) {
-      if (featureDef.options){
-        const optionsArray = Object.values(featureDef.options);
-        const { optionKeyError, optionKeyErrorMsg } = utils.validateKeyInOptions(optionsArray);
-        if (optionKeyError) return logError(optionKeyErrorMsg);
-      }
-    }
+    const { optionKeyError, optionKeyErrorMsg } = utils.validateFeatureDataOptions(featureDefsData);
+    if (optionKeyError) return logError(optionKeyErrorMsg);
   }
+
 
   if (json["dataset"]) {
     const totalCells = json.dataset.userData.totalCells;

--- a/bin/check-single-dataset.js
+++ b/bin/check-single-dataset.js
@@ -20,21 +20,21 @@ const checkForError = (fileName, json, schemaFileName) => {
   if (json["feature-defs"]) {
     const featuresDataOrder = json.dataset.featuresDataOrder;
     const featureDefsData = json["feature-defs"];
-    const result = utils.validateFeatureDataKeys(
+    const { featureKeysError, keysErrorMsg } = utils.validateFeatureDataKeys(
       featuresDataOrder,
       featureDefsData
     );
-    if (result.featureKeysError) {
-      datasetsError = result.featureKeysError;
-      errorMsg = result.keysErrorMsg;
+    if (featureKeysError) {
+      datasetsError = featureKeysError;
+      errorMsg = keysErrorMsg;
     };
     for (let featureDef of featureDefsData) {
       if (featureDef.options){
         const optionsArray = Object.values(featureDef.options);
-        const results = utils.validateKeyInOptions(optionsArray);
-        if (results.optionKeyError) {
-          datasetsError = results.optionKeyError;
-          errorMsg = results.optionKeyErrorMsg;
+        const { optionKeyError, optionKeyErrorMsg } = utils.validateKeyInOptions(optionsArray);
+        if (optionKeyError) {
+          datasetsError = optionKeyError;
+          errorMsg = optionKeyErrorMsg;
         }
       }
     }
@@ -42,10 +42,10 @@ const checkForError = (fileName, json, schemaFileName) => {
   if (json["dataset"]) {
     const totalCells = json.dataset.userData.totalCells;
     const totalFOVs = json.dataset.userData.totalFOVs;
-    const result = utils.validateUserDataValues(totalCells, totalFOVs);
-    if (result.userDataError) {
-      datasetsError = result.userDataError;
-      errorMsg = result.userDataErrorMsg;
+    const { userDataError, userDataErrorMsg }= utils.validateUserDataValues(totalCells, totalFOVs);
+    if (userDataError) {
+      datasetsError = userDataError;
+      errorMsg = userDataErrorMsg;
     }
   }
 

--- a/bin/check-single-dataset.js
+++ b/bin/check-single-dataset.js
@@ -15,41 +15,7 @@ const checkForError = (fileName, json, schemaFileName) => {
     json,
     ajv.getSchema(schemaFileName)
   );
-  let datasetsError = false;
-  let errorMsg = "";
-  if (json["feature-defs"]) {
-    const featuresDataOrder = json.dataset.featuresDataOrder;
-    const featureDefsData = json["feature-defs"];
-    const { featureKeysError, keysErrorMsg } = utils.validateFeatureDataKeys(
-      featuresDataOrder,
-      featureDefsData
-    );
-    if (featureKeysError) {
-      datasetsError = featureKeysError;
-      errorMsg = keysErrorMsg;
-    };
-    for (let featureDef of featureDefsData) {
-      if (featureDef.options){
-        const optionsArray = Object.values(featureDef.options);
-        const { optionKeyError, optionKeyErrorMsg } = utils.validateKeyInOptions(optionsArray);
-        if (optionKeyError) {
-          datasetsError = optionKeyError;
-          errorMsg = optionKeyErrorMsg;
-        }
-      }
-    }
-  }
-  if (json["dataset"]) {
-    const totalCells = json.dataset.userData.totalCells;
-    const totalFOVs = json.dataset.userData.totalFOVs;
-    const { userDataError, userDataErrorMsg }= utils.validateUserDataValues(totalCells, totalFOVs);
-    if (userDataError) {
-      datasetsError = userDataError;
-      errorMsg = userDataErrorMsg;
-    }
-  }
-
-  if (!valid || datasetsError) {
+  const logError = (errorMsg) => {
     console.log(
       "\x1b[0m",
       `${fileName}`,
@@ -58,7 +24,8 @@ const checkForError = (fileName, json, schemaFileName) => {
       "\x1b[0m"
     );
     return true;
-  } else {
+  };
+  const logSuccess = () => {
     console.log(
       "\x1b[0m",
       `${fileName}: check against ${schemaFileName}`,
@@ -67,7 +34,35 @@ const checkForError = (fileName, json, schemaFileName) => {
       "\x1b[0m"
     );
     return false;
+  };
+  if (!valid) return logError(errorMsg);
+
+  if (json["feature-defs"]) {
+    const featuresDataOrder = json.dataset.featuresDataOrder;
+    const featureDefsData = json["feature-defs"];
+    const { featureKeysError, keysErrorMsg } = utils.validateFeatureDataKeys(
+      featuresDataOrder,
+      featureDefsData
+    );
+    if (featureKeysError) return logError(keysErrorMsg);
+
+    for (let featureDef of featureDefsData) {
+      if (featureDef.options){
+        const optionsArray = Object.values(featureDef.options);
+        const { optionKeyError, optionKeyErrorMsg } = utils.validateKeyInOptions(optionsArray);
+        if (optionKeyError) return logError(optionKeyErrorMsg);
+      }
+    }
   }
+
+  if (json["dataset"]) {
+    const totalCells = json.dataset.userData.totalCells;
+    const totalFOVs = json.dataset.userData.totalFOVs;
+    const { userDataError, userDataErrorMsg }= utils.validateUserDataValues(totalCells, totalFOVs);
+    if (userDataError) return logError(userDataErrorMsg);
+  }
+
+  return logSuccess();
 };
 
 const checkSingleDatasetInput = async (datasetFolder) => {

--- a/bin/check-single-dataset.js
+++ b/bin/check-single-dataset.js
@@ -27,6 +27,16 @@ const checkForError = (fileName, json, schemaFileName) => {
     if (result.featureKeysError) {
       datasetsError = result.featureKeysError;
       errorMsg = result.keysErrorMsg;
+    };
+    for (let featureDef of featureDefsData) {
+      if (featureDef.options){
+        const optionsArray = Object.values(featureDef.options);
+        const results = utils.validateKeyInOptions(optionsArray);
+        if (results.optionKeyError) {
+          datasetsError = results.optionKeyError;
+          errorMsg = results.optionKeyErrorMsg;
+        }
+      }
     }
   }
   if (json["dataset"]) {

--- a/src/process-single-dataset/index.js
+++ b/src/process-single-dataset/index.js
@@ -48,6 +48,16 @@ const processSingleDataset = async (
     console.error(keysErrorMsg);
     process.exit(1);
   };
+  for (let featureDef of featureDefsData) {
+    if (featureDef.options){
+      const optionsArray = Object.values(featureDef.options);
+      const {optionKeyError, optionKeyErrorMsg} = utils.validateKeyInOptions(optionsArray);
+      if (optionKeyError) {
+        console.error(optionKeyErrorMsg);
+        process.exit(1);
+      }
+    }  
+  };
   const totalCells = datasetJson.userData.totalCells;
   const totalFOVs = datasetJson.userData.totalFOVs;
   const {userDataError, userDataErrorMsg} = utils.validateUserDataValues(totalCells, totalFOVs);

--- a/src/process-single-dataset/index.js
+++ b/src/process-single-dataset/index.js
@@ -48,15 +48,10 @@ const processSingleDataset = async (
     console.error(keysErrorMsg);
     process.exit(1);
   };
-  for (let featureDef of featureDefsData) {
-    if (featureDef.options){
-      const optionsArray = Object.values(featureDef.options);
-      const {optionKeyError, optionKeyErrorMsg} = utils.validateKeyInOptions(optionsArray);
-      if (optionKeyError) {
-        console.error(optionKeyErrorMsg);
-        process.exit(1);
-      }
-    }  
+  const { optionKeyError, optionKeyErrorMsg } = utils.validateFeatureDataOptions(featureDefsData);
+  if (optionKeyError) {
+    console.error(optionKeyErrorMsg);
+    process.exit(1);
   };
   const totalCells = datasetJson.userData.totalCells;
   const totalFOVs = datasetJson.userData.totalFOVs;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -41,48 +41,41 @@ const readPossibleZippedFile = async (folder, fileName) => {
 }
 
 const validateFeatureDataKeys = (featuresDataOrder, featureDefs) => {
-    let featureKeysError = false;
-    let keysErrorMsg = "";
     const keyList = Array.from(featureDefs, (featureDataJson) => featureDataJson.key);
     if (featuresDataOrder.length > keyList.length) {
-        keysErrorMsg = 
+        const keysErrorMsg = 
             `Error: featureDefs has ${keyList.length} features but there are ${featuresDataOrder.length} listed in featuresDataOrder`;
-        featureKeysError = true;
-        return { featureKeysError, keysErrorMsg };
+        return { featureKeysError: true, keysErrorMsg };
     };
-    featuresDataOrder.forEach((keyName) => {
+    for (const keyName of featuresDataOrder) {
         if (!keyList.includes(keyName)) {
-            keysErrorMsg =
+            const keysErrorMsg =
                 `Error: key ${keyName} in featuresDataOrder does not exist in featureDefs`;
-            featureKeysError = true;
-            return { featureKeysError, keysErrorMsg };
+            return { featureKeysError: true, keysErrorMsg };
         }
-    });
-    return { featureKeysError, keysErrorMsg };
+    }
+    return { featureKeysError: false, keysErrorMsg: "" };
 };
 
 const validateUserDataValues = (totalCells, totalFOVs) => {
-    let userDataError = false;
-    let userDataErrorMsg = "";
     if (!totalCells && !totalFOVs) {
-        userDataErrorMsg = "Error: totalCells and totalFOVs can't both be zero or undefined";
-        userDataError = true;
-    };
-    return { userDataError, userDataErrorMsg };
+        const userDataErrorMsg = "Error: totalCells and totalFOVs can't both be zero or undefined";
+        return { userDataError: true, userDataErrorMsg };
+    }
+    return { userDataError: false, userDataErrorMsg: "" };
 };
 
 const validateKeyInOptions = (options) => {
-    let optionKeyError = false;
-    let optionKeyErrorMsg = "";
     const uniqueNames = new Set();
-    options.forEach((option) => {
+
+    for (const option of options) {
         if (uniqueNames.has(option.name) && !option.key) {
-            optionKeyErrorMsg = `Error: option name ${option.name} is not unique, key is required`;
-            optionKeyError = true;
+            const optionKeyErrorMsg = `Error: option ${option.name} is not unique, key is required`;
+            return { optionKeyError: true, optionKeyErrorMsg };
         }
         uniqueNames.add(option.name);
-    });
-    return { optionKeyError, optionKeyErrorMsg };
+    }
+    return { optionKeyError: false, optionKeyErrorMsg: "" };
 };
 
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -71,10 +71,26 @@ const validateUserDataValues = (totalCells, totalFOVs) => {
     return { userDataError, userDataErrorMsg };
 };
 
+const validateKeyInOptions = (options) => {
+    let optionKeyError = false;
+    let optionKeyErrorMsg = "";
+    const uniqueNames = new Set();
+    options.forEach((option) => {
+        if (uniqueNames.has(option.name) && !option.key) {
+            optionKeyErrorMsg = `Error: option name ${option.name} is not unique, key is required`;
+            optionKeyError = true;
+        }
+        uniqueNames.add(option.name);
+    });
+    return { optionKeyError, optionKeyErrorMsg };
+};
+
+
 module.exports = {
     readDatasetJson,
     readAndParseFile, 
     readPossibleZippedFile,
     validateFeatureDataKeys,
-    validateUserDataValues
+    validateUserDataValues,
+    validateKeyInOptions,
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -78,6 +78,19 @@ const validateKeyInOptions = (options) => {
     return { optionKeyError: false, optionKeyErrorMsg: "" };
 };
 
+const validateFeatureDataOptions = (featureDefsData) => {
+    for (let featureDef of featureDefsData) {
+        if (featureDef.options){
+            const options = Object.values(featureDef.options);
+            const {optionKeyError, optionKeyErrorMsg} = validateKeyInOptions(options);
+            if (optionKeyError) {
+                return { optionKeyError, optionKeyErrorMsg };
+            }
+        }
+    }
+    return { optionKeyError: false, optionKeyErrorMsg: "" };
+};
+
 
 module.exports = {
     readDatasetJson,
@@ -85,5 +98,5 @@ module.exports = {
     readPossibleZippedFile,
     validateFeatureDataKeys,
     validateUserDataValues,
-    validateKeyInOptions,
+    validateFeatureDataOptions,
 }


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #89 

Solution
========
What I/we did to solve this problem
- added a validation in `utils` to check if a `name` in `options` is unique or not.  If it's not unique, `key` is required

with @meganrm 

I am also thinking about integrating our validations from `utils` into the current ajv schema, so we'd only need to make edits in one place (the schema) rather than adding validations to both `check-single-dataset` and `process-single-dataset`. Future reorganizations and refactors may be needed. 

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)


Steps to Verify:
----------------
1. Change the value in `feature_defs.json` of a single dataset for testing: modify a `name` in `options` to a not unique one
2. Run `npm run validate-datasets`, `npm run validate-single-dataset [DATASET-PATH]` and `npm run process-dataset [DATASET-PATH]` to check if raises en error without a `key`

Expected Behavior:
---------------------
 
<img width="1007" alt="Screenshot 2023-08-28 at 2 52 15 PM" src="https://github.com/allen-cell-animated/cell-feature-data/assets/91452427/94bd69a4-014b-4d04-ab05-c7680da82afb">

<img width="1040" alt="Screenshot 2023-08-28 at 2 29 38 PM" src="https://github.com/allen-cell-animated/cell-feature-data/assets/91452427/627435dc-65c8-4195-8ca2-66024cf3c8be">


