### PR TITLE
Maintenance: adjust settings to non-required in schema 

### DIFF
--- a/bin/check-single-dataset.js
+++ b/bin/check-single-dataset.js
@@ -35,7 +35,7 @@ const checkForError = (fileName, json, schemaFileName) => {
     );
     return false;
   };
-  if (!valid) return logError(errorMsg);
+  if (!valid) return logError(error);
 
   if (json["feature-defs"]) {
     const featuresDataOrder = json.dataset.featuresDataOrder;

--- a/src/data-validation/schema/dataset-card.schema.json
+++ b/src/data-validation/schema/dataset-card.schema.json
@@ -44,7 +44,6 @@
         "title",
         "version",
         "name",
-        "image",
         "description"
     ]
 }

--- a/src/data-validation/schema/feature-def.schema.json
+++ b/src/data-validation/schema/feature-def.schema.json
@@ -38,8 +38,6 @@
     },
     "required": [
         "displayName",
-        "description",
-        "tooltip",
         "unit",
         "key",
         "discrete"

--- a/src/data-validation/schema/input-dataset-info.schema.json
+++ b/src/data-validation/schema/input-dataset-info.schema.json
@@ -93,7 +93,6 @@
         "description",
         "featuresDataPath",
         "viewerSettingsPath",
-        "albumPath",
         "thumbnailRoot",
         "downloadRoot",
         "volumeViewerDataRoot",

--- a/src/data-validation/schema/input-dataset-info.schema.json
+++ b/src/data-validation/schema/input-dataset-info.schema.json
@@ -91,7 +91,6 @@
         "name",
         "description",
         "featuresDataPath",
-        "viewerSettingsPath",
         "thumbnailRoot",
         "downloadRoot",
         "volumeViewerDataRoot",

--- a/src/data-validation/schema/input-dataset-info.schema.json
+++ b/src/data-validation/schema/input-dataset-info.schema.json
@@ -89,7 +89,6 @@
         "title",
         "version",
         "name",
-        "image",
         "description",
         "featuresDataPath",
         "viewerSettingsPath",

--- a/src/data-validation/unpack-input-dataset.js
+++ b/src/data-validation/unpack-input-dataset.js
@@ -9,9 +9,13 @@ const unpackInputDataset = async (datasetReadFolder) => {
   const featureDefs = await readAndParseFile(
     `${datasetReadFolder}/${datasetJson.featureDefsPath}`
   );
-  const images = await readAndParseFile(
-    `${datasetReadFolder}/${datasetJson.viewerSettingsPath}`
-  );
+  let images = {};
+  if (datasetJson.viewerSettingsPath) {
+
+    images = await readAndParseFile(
+      `${datasetReadFolder}/${datasetJson.viewerSettingsPath}`
+    );
+  }
   const measuredFeatures = await readPossibleZippedFile(
     datasetReadFolder,
     datasetJson.featuresDataPath
@@ -21,7 +25,7 @@ const unpackInputDataset = async (datasetReadFolder) => {
     dataset: datasetJson,
     "feature-defs": featureDefs,
     "measured-features": measuredFeatures,
-    images: images,
+    images,
   };
   return inputDataset;
 };


### PR DESCRIPTION
Problem
=======
What is the problem this work solves, including
closes #92 

Estimated review time: small, <10 minutes

Solution
========
What I/we did to solve this problem
Removed the following settings from the `required` list in the schema to ensure consistency 

In `dataset.json`:
- `image`
- `albumPath`
- `viewerSettingPath`

In `feature_def.json`:
- `tooltip`
- `description` 

with @meganrm 

## Type of change
Please delete options that are not relevant.
* This change requires a documentation update